### PR TITLE
treat securetty config as an array

### DIFF
--- a/roles/ansible-os-hardening/templates/securetty.j2
+++ b/roles/ansible-os-hardening/templates/securetty.j2
@@ -3,4 +3,4 @@
 
 # A list of TTYs, from which root can log in
 # see `man securetty` for reference
-{{ os_auth_root_ttys }}
+{{ "\n".join(os_auth_root_ttys) }}

--- a/roles/ansible-os-hardening/vars/main.yml
+++ b/roles/ansible-os-hardening/vars/main.yml
@@ -17,7 +17,7 @@ os_auth_timeout:  60
 os_auth_allow_homeless:  false
 os_auth_pam_passwdqc_enable:  true
 os_auth_pam_passwdqc_options: 'disabled,disabled,16,12,8'
-os_auth_root_ttys:  '%w(console tty1 tty2 tty3 tty4 tty5 tty6)'
+os_auth_root_ttys:  [console, tty1, tty2, tty3, tty4, tty5, tty6]
 os_auth_uid_min:  1000
 os_auth_gid_min:  1000
 os_chfn_restrict: ''


### PR DESCRIPTION
We expect securetty file to look something like this:
```
console
tty1
tty2
tty3
tty4
```

So treat the config as an array/list and put every entry in a line.