### PR TITLE
Use changed_when to avoid changed tasks

### DIFF
--- a/roles/ansible-os-hardening/tasks/rhosts.yml
+++ b/roles/ansible-os-hardening/tasks/rhosts.yml
@@ -1,6 +1,7 @@
 ---
 - name: Get user accounts | DTAG SEC Req 3.21-4
   command: "awk -F: '{print $1}' /etc/passwd"
+  changed_when: False
   register: users
 
 - name: delete rhosts-files from system | DTAG SEC Req 3.21-4

--- a/roles/ansible-os-hardening/tasks/suid_sgid.yml
+++ b/roles/ansible-os-hardening/tasks/suid_sgid.yml
@@ -10,6 +10,7 @@
   shell: find / -xdev \( -perm -4000 -o -perm -2000 \) -type f ! -path '/proc/*' -print 2>/dev/null
   register: sbit_binaries
   when: os_security_suid_sgid_remove_from_unknown
+  changed_when: False
 
 - name: gather files from which to remove suids/sgids and remove system white-listed files
   set_fact:

--- a/roles/ansible-os-hardening/tasks/yum.yml
+++ b/roles/ansible-os-hardening/tasks/yum.yml
@@ -9,6 +9,7 @@
 
 - name: get yum-repository-files
   shell: 'find /etc/yum.repos.d/ -type f -name *.repo'
+  changed_when: False
   register: yum_repos
 
 - name: check if rhnplugin.conf exists


### PR DESCRIPTION
When a `shell` or `command` task, that only fetches data, gets executed,
the task will be marked as `changed`, even though nothing changed.
This commit changes the behaviour of tasks that only fetch data.
For more info see here:
http://docs.ansible.com/playbooks_error_handling.html#overriding-the-changed-result