### PR TITLE
List-cleanup and follow symlinks added

### DIFF
--- a/roles/ansible-os-hardening/tasks/main.yml
+++ b/roles/ansible-os-hardening/tasks/main.yml
@@ -10,6 +10,8 @@
 - include: profile.yml tags=profile
 - include: securetty.yml tags=securetty
 - include: suid_sgid.yml tags=suid_sgid
+  when: os_security_suid_sgid_enforce
+
 - include: sysctl.yml tags=sysctl
 - include: user_accounts.yml tags=user_accounts
 - include: rhosts.yml tags=rhosts

--- a/roles/ansible-os-hardening/tasks/suid_sgid.yml
+++ b/roles/ansible-os-hardening/tasks/suid_sgid.yml
@@ -1,6 +1,6 @@
 ---
 - name: remove suid/sgid bit from binaries in blacklist
-  file: path='{{item}}' mode='a-s'
+  file: path='{{item}}' mode='a-s' state=file follow=yes
   ignore_errors: true
   with_items:
     - '{{ os_security_suid_sgid_system_blacklist }}'
@@ -18,7 +18,7 @@
   when: os_security_suid_sgid_remove_from_unknown
 
 - name: remove suid/sgid bit from all binaries except in system and user whitelist
-  file: path='{{item}}' mode='a-s' state=file
+  file: path='{{item}}' mode='a-s' state=file follow=yes
   with_items:
     - '{{ suid | difference(os_security_suid_sgid_whitelist) }}'
   when: os_security_suid_sgid_remove_from_unknown

--- a/roles/ansible-os-hardening/vars/main.yml
+++ b/roles/ansible-os-hardening/vars/main.yml
@@ -51,82 +51,103 @@ os_security_kernel_secure_sysrq: 4 + 16 + 32 + 64 + 128
 # adjust values for blacklist/whitelist instead, they can override system_blacklist/whitelist
 
 # list of suid/sgid entries that must be removed
-os_security_suid_sgid_system_blacklist: [
+os_security_suid_sgid_system_blacklist: 
   # blacklist as provided by NSA
-  '/usr/bin/rcp', '/usr/bin/rlogin', '/usr/bin/rsh',
+  - '/usr/bin/rcp'
+  - '/usr/bin/rlogin'
+  - '/usr/bin/rsh'
   # sshd must not use host-based authentication (see ssh cookbook)
-  '/usr/libexec/openssh/ssh-keysign',
-  '/usr/lib/openssh/ssh-keysign',
+  - '/usr/libexec/openssh/ssh-keysign'
+  - '/usr/lib/openssh/ssh-keysign'
   # misc others
-  '/sbin/netreport', # not normally required for user
-  '/usr/sbin/usernetctl', # modify interfaces via functional accounts
+  - '/sbin/netreport'                                            # not normally required for user
+  - '/usr/sbin/usernetctl'                                       # modify interfaces via functional accounts
   # connecting to ...
-  '/usr/sbin/userisdnctl',                                      # no isdn...
-  '/usr/sbin/pppd',                                             # no ppp / dsl ...
+  - '/usr/sbin/userisdnctl'                                      # no isdn...
+  - '/usr/sbin/pppd'                                             # no ppp / dsl ...
   # lockfile
-  '/usr/bin/lockfile',
-  '/usr/bin/mail-lock',
-  '/usr/bin/mail-unlock',
-  '/usr/bin/mail-touchlock',
-  '/usr/bin/dotlockfile',
-  # need more investigation, blacklist for now
-  '/usr/bin/arping',
-  '/usr/sbin/uuidd',
-  '/usr/bin/mtr',                                               # investigate current state...
-  '/usr/lib/evolution/camel-lock-helper-1.2',                   # investigate current state...
-  '/usr/lib/pt_chown',                                          # pseudo-tty, needed?
-  '/usr/lib/eject/dmcrypt-get-device',
-  '/usr/lib/mc/cons.saver'                                      # midnight commander screensaver
-]
+  - '/usr/bin/lockfile'
+  - '/usr/bin/mail-lock'
+  - '/usr/bin/mail-unlock'
+  - '/usr/bin/mail-touchlock'
+  - '/usr/bin/dotlockfile'
+  # need more investigation blacklist for now
+  - '/usr/bin/arping'
+  - '/usr/sbin/uuidd'
+  - '/usr/bin/mtr'                                               # investigate current state...
+  - '/usr/lib/evolution/camel-lock-helper-1.2'                   # investigate current state...
+  - '/usr/lib/pt_chown'                                          # pseudo-tty needed?
+  - '/usr/lib/eject/dmcrypt-get-device'
+  - '/usr/lib/mc/cons.saver'                                      # midnight commander screensaver
 
 # list of suid/sgid entries that can remain untouched
-os_security_suid_sgid_system_whitelist:  [
+os_security_suid_sgid_system_whitelist:
   # whitelist as provided by NSA
-  '/bin/mount', '/bin/ping', '/bin/su', '/bin/umount', '/sbin/pam_timestamp_check',
-  '/sbin/unix_chkpwd', '/usr/bin/at', '/usr/bin/gpasswd', '/usr/bin/locate',
-  '/usr/bin/newgrp', '/usr/bin/passwd', '/usr/bin/ssh-agent', '/usr/libexec/utempter/utempter', '/usr/sbin/lockdev',
-  '/usr/sbin/sendmail.sendmail', '/usr/bin/expiry',
+  - '/bin/mount'
+  - '/bin/ping'
+  - '/bin/su'
+  - '/bin/umount'
+  - '/sbin/pam_timestamp_check'
+  - '/sbin/unix_chkpwd'
+  - '/usr/bin/at'
+  - '/usr/bin/gpasswd'
+  - '/usr/bin/locate'
+  - '/usr/bin/newgrp'
+  - '/usr/bin/passwd'
+  - '/usr/bin/ssh-agent'
+  - '/usr/libexec/utempter/utempter'
+  - '/usr/sbin/lockdev'
+  - '/usr/sbin/sendmail.sendmail'
+  - '/usr/bin/expiry'
   # whitelist ipv6
-  '/bin/ping6', '/usr/bin/traceroute6.iputils',
+  - '/bin/ping6'
+  - '/usr/bin/traceroute6.iputils'
   # whitelist nfs
-  '/sbin/mount.nfs', '/sbin/umount.nfs',
+  - '/sbin/mount.nfs'
+  - '/sbin/umount.nfs'
   # whitelist nfs4
-  '/sbin/mount.nfs4', '/sbin/umount.nfs4',
+  - '/sbin/mount.nfs4'
+  - '/sbin/umount.nfs4'
   # whitelist cron
-  '/usr/bin/crontab',
+  - '/usr/bin/crontab'
   # whitelist consolemssaging
-  '/usr/bin/wall', '/usr/bin/write',
+  - '/usr/bin/wall'
+  - '/usr/bin/write'
   # whitelist: only SGID with utmp group for multi-session access
-  #            impact is limited; installation/usage has some remaining risk
-  '/usr/bin/screen',
+  # impact is limited; installation/usage has some remaining risk
+  - '/usr/bin/screen'
   # whitelist locate
-  '/usr/bin/mlocate',
+  - '/usr/bin/mlocate'
   # whitelist usermanagement
-  '/usr/bin/chage', '/usr/bin/chfn', '/usr/bin/chsh',
+  - '/usr/bin/chage'
+  - '/usr/bin/chfn'
+  - '/usr/bin/chsh'
   # whitelist fuse
-  '/bin/fusermount',
+  - '/bin/fusermount'
   # whitelist pkexec
-  '/usr/bin/pkexec',
+  - '/usr/bin/pkexec'
   # whitelist sudo
-  '/usr/bin/sudo', '/usr/bin/sudoedit',
+  - '/usr/bin/sudo'
+  - '/usr/bin/sudoedit'
   # whitelist postfix
-  '/usr/sbin/postdrop', '/usr/sbin/postqueue',
+  - '/usr/sbin/postdrop'
+  - '/usr/sbin/postqueue'
   # whitelist apache
-  '/usr/sbin/suexec',
+  - '/usr/sbin/suexec'
   # whitelist squid
-  '/usr/lib/squid/ncsa_auth', '/usr/lib/squid/pam_auth',
+  - '/usr/lib/squid/ncsa_auth'
+  - '/usr/lib/squid/pam_auth'
   # whitelist kerberos
-  '/usr/kerberos/bin/ksu',
+  - '/usr/kerberos/bin/ksu'
   # whitelist pam_caching
-  '/usr/sbin/ccreds_validate',
+  - '/usr/sbin/ccreds_validate'
   # whitelist Xorg
-  '/usr/bin/Xorg',                                              # xorg
-  '/usr/bin/X',                                                 # xorg
-  '/usr/lib/dbus-1.0/dbus-daemon-launch-helper',                # freedesktop ipc
-  '/usr/lib/vte/gnome-pty-helper',                              # gnome
-  '/usr/lib/libvte9/gnome-pty-helper',                          # gnome
-  '/usr/lib/libvte-2.90-9/gnome-pty-helper'                     # gnome
-]
+  - '/usr/bin/Xorg'                                              # xorg
+  - '/usr/bin/X'                                                 # xorg
+  - '/usr/lib/dbus-1.0/dbus-daemon-launch-helper'                # freedesktop ipc
+  - '/usr/lib/vte/gnome-pty-helper'                              # gnome
+  - '/usr/lib/libvte9/gnome-pty-helper'                          # gnome
+  - '/usr/lib/libvte-2.90-9/gnome-pty-helper'                     # gnome
 
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root','sync','shutdown','halt']


### PR DESCRIPTION
- This change alters the black- and white-listed list for
suid/sgid-management to be a proper yaml-formatted list.

- Furthermore "follow symlinks" was added to the tasks
that remove suid/sgid because otherwise the suid/sgid
from the link-targets would not be removed.