### PR TITLE
Create limits.d-directory if it does not exist.

### DIFF
--- a/roles/ansible-os-hardening/tasks/limits.yml
+++ b/roles/ansible-os-hardening/tasks/limits.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: create limits.d-directory if it does not exist
+  file: path='/etc/security/limits.d' owner=root group=root mode=0755 state=directory
+  when: os_security_kernel_enable_core_dump
+
 - name: create sane limits.conf
   template: src='limits.conf.j2' dest='/etc/security/limits.d/10.hardcore.conf' owner=root group=root mode=0440
   when: os_security_kernel_enable_core_dump


### PR DESCRIPTION
On certain OSes the directory does not exist, so the following task would fail.
See [here](https://github.com/hardening-io/chef-os-hardening/issues/84) for more info.