### PR TITLE
Fix stuck in case pam files was updated before by force update

### DIFF
--- a/roles/ansible-os-hardening/tasks/pam.yml
+++ b/roles/ansible-os-hardening/tasks/pam.yml
@@ -2,6 +2,9 @@
 - name: update pam on Debian systems
   command: 'pam-auth-update --package'
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  changed_when: False
+  environment:
+    DEBIAN_FRONTEND: noninteractive
 
 - name: remove pam ccreds on Debian systems
   apt: name='{{os_packages_pam_ccreds}}' state=absent


### PR DESCRIPTION
If pam settings were updated by user the command just stucks because in OS pop-up appears and asks what should it do. By force option question is eliminate so no stucks anymore