### PR TITLE
Add explicit role-path to kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,5 +53,7 @@ suites:
   hosts: all
   ansible_verbose: true
   ansible_version: 1.9.2
+  ansible_diff: true
+  roles_path: ../ansible-os-hardening/
   provisioner:
     playbook: test/integration/playbooks/default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,8 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
-#  gem 'chefspec',   '~> 4.2.0'
   gem 'foodcritic', '~> 4.0'
   gem 'thor-foodcritic'
-#  gem 'rubocop',    '~> 0.28.0'
   gem 'coveralls',  require: false
 end
 
@@ -15,8 +13,6 @@ group :development do
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-kitchen'
-#  gem 'guard-rubocop'
-#  gem 'guard-foodcritic'
 end
 
 group :integration do
@@ -24,6 +20,8 @@ group :integration do
   gem 'kitchen-ansible'
   gem 'kitchen-vagrant'
   gem 'kitchen-sharedtests', '~> 0.2.0'
+  gem 'kitchen-sync'
+  gem 'kitchen-transport-rsync'
 end
 
 group :openstack do


### PR DESCRIPTION
Before this PR role path was searched with regex in the docroot.
Now it's explicitly declared.

Also added two gems to gemfile for faster copying to virtualbox and ansible diff.