### PR TITLE
ERROR! Include tasks should not specify tags in more than one way

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,21 +3,33 @@
   include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
-- include: limits.yml tags=limits
-- include: login_defs.yml tags=login_defs
-- include: minimize_access.yml tags=minimize_acces
-- include: pam.yml tags=pam
-- include: profile.yml tags=profile
-- include: securetty.yml tags=securetty
-- include: suid_sgid.yml tags=suid_sgid
+- include: limits.yml
+  tags: limits
+- include: login_defs.yml
+  tags: login_defs
+- include: minimize_access.yml
+  tags: minimize_acces
+- include: pam.yml
+  tags: pam
+- include: profile.yml
+  tags: profile
+- include: securetty.yml
+  tags: securetty
+- include: suid_sgid.yml
+  tags: suid_sgid
   when: os_security_suid_sgid_enforce
 
-- include: sysctl.yml tags=sysctl
-- include: user_accounts.yml tags=user_accounts
-- include: rhosts.yml tags=rhosts
+- include: sysctl.yml
+  tags: sysctl
+- include: user_accounts.yml
+  tags: user_accounts
+- include: rhosts.yml
+  tags: rhosts
 
-- include: yum.yml tags=yum
+- include: yum.yml
+  tags: yum
   when: ansible_os_family == 'RedHat' or ansible_os_family == 'Oracle Linux'
 
-- include: apt.yml tags=apt
+- include: apt.yml
+  tags: apt
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
TASK [ansible-os-hardening : include] ******************************************
ERROR! Include tasks should not specify tags in more than one way (both via args and directly on the task)

The error appears to have been in '/home/fitz123/Copy/ProjectStreaming/ServersConfig/Autodeploy/ansible/roles/ansible-os-hardening/tasks/main.yml': line 6, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- include: limits.yml tags=limits
  ^ here
