### PR TITLE
Updates "tags" parameters on includes in main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,21 +3,42 @@
   include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
-- include: limits.yml tags=limits
-- include: login_defs.yml tags=login_defs
-- include: minimize_access.yml tags=minimize_acces
-- include: pam.yml tags=pam
-- include: profile.yml tags=profile
-- include: securetty.yml tags=securetty
-- include: suid_sgid.yml tags=suid_sgid
+- include: limits.yml
+  tags: limits
+
+- include: login_defs.yml
+  tags: login_defs
+
+- include: minimize_access.yml
+  tags: minimize_acces
+
+- include: pam.yml
+  tags: pam
+
+- include: profile.yml
+  tags: profile
+
+- include: securetty.yml
+  tags: securetty
+
+- include: suid_sgid.yml
   when: os_security_suid_sgid_enforce
+  tags: suid_sgid
 
-- include: sysctl.yml tags=sysctl
-- include: user_accounts.yml tags=user_accounts
-- include: rhosts.yml tags=rhosts
+- include: sysctl.yml
+  tags: sysctl
 
-- include: yum.yml tags=yum
+- include: user_accounts.yml
+  tags: user_accounts
+
+- include: rhosts.yml
+  tags: rhosts
+
+- include: yum.yml
   when: ansible_os_family == 'RedHat' or ansible_os_family == 'Oracle Linux'
+  tags: yum
 
-- include: apt.yml tags=apt
+- include: apt.yml
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  tags: apt
+


### PR DESCRIPTION
Ansible v2 forbids in-line tags on include statements, and expects "tags" to be always a task-level parameter. Older versions of Ansible support both styles, so it makes sense to standardize on the latter.

Here's a vim one-liner to help with this conversion (I've been doing it a lot lately):

`:%s/ tags=\(\w\+\)/^M  tags: \1^M/g`

With a bit of manual cleanup it saves a lot of time.