### PR TITLE
Supports selectively overriding net.ipv4.ip_forward sysctl var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It will not:
 * `os_security_suid_sgid_whitelist: []` - a list of paths which should not have their SUID/SGID bits altered
 * `os_security_suid_sgid_remove_from_unknown: false` - true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Ansible-run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`.
 * `os_security_packages_clean': true` - removes packages with known issues. See section packages.
+* `os_network_forwarding: false` - forbid IPv4 forwarding via sysctl. Set to true for routers or VPN hosts.
 
 ## Packages
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,13 +40,16 @@ os_security_init_prompt: true
 # Require root password for single user mode. (rhel, centos)
 os_security_init_single: false
 
+# Forbid IPv4 forwarding via sysctl. You may override only this variable to change the value
+# of `net.ipv4.ip_forward` without overriding the entire `sysctl_config` dict.
+os_network_forwarding: false
+
 # CAUTION
 # If you want to overwrite sysctl-variables,
 # you have to overwrite the *whole* dict, or else only the single overwritten will be actually used.
-
 sysctl_config:
   # Disable IPv4 traffic forwarding.
-  net.ipv4.ip_forward: 0
+  net.ipv4.ip_forward: "{{ '1' if os_network_forwarding else '0' }}"
 
   # Disable IPv6 traffic forwarding.
   net.ipv6.conf.all.forwarding: 0


### PR DESCRIPTION
The README previously documented a non-existent default var called `os_network_forwarding`. This commit adds it back, with documentation. The goal is to support selectively overriding only a single sysctl var, that which permits IPv4 forwarding. Presumably this is the most commonly overridden sysctl var for this role—see #50 for discussion.

This commit simply adds sugar to the outstanding #67. @fitz123, feel free to chime in if this is useful for you too.

